### PR TITLE
feat: remove pre-registration sync function

### DIFF
--- a/src/CommercetoolsAuth0.ts
+++ b/src/CommercetoolsAuth0.ts
@@ -7,7 +7,6 @@ import {
   PostLoginSyncParams,
   MergeAnonymousToAccountCartParams,
   MergeCartParams,
-  PreRegistrationSyncParams,
   GetCartParams,
   PostRegistrationSyncParams,
 } from './types'
@@ -63,17 +62,6 @@ export class CommercetoolsAuth0 {
       })
     }
     return customer
-  }
-
-  /**
-   * Pre-registration synchronisation functionality
-   *
-   * This method should be called when the pre-registration action is executed.
-   * We do not have access to the Auth0 user id at this point, and so cannot set
-   * the externalId property on the commercetools customer record at this point.
-   */
-  public async preRegistrationSync(options: PreRegistrationSyncParams): Promise<Customer> {
-    return await this.createCustomer(options)
   }
 
   /**

--- a/src/__tests__/CommercetoolsAuth0.test.ts
+++ b/src/__tests__/CommercetoolsAuth0.test.ts
@@ -1,7 +1,6 @@
 import { CommercetoolsAuth0 } from '../CommercetoolsAuth0'
 import { Cart } from '@gradientedge/commercetools-utils'
 import { mockCart, mockClientGrantResponse, mockConfig, mockCustomer } from './mocks'
-import { CommercetoolsAuth0Error } from '../error'
 import nock from 'nock'
 import _ from 'lodash'
 
@@ -111,99 +110,6 @@ describe('CommercetoolsAuth0', () => {
 
       expect(result).toBeNull()
       expect(commercetoolsAuth0.mergeCart).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('preRegistrationSync', () => {
-    it('should return the customer object when successfully created in commercetools', async () => {
-      nock('https://api.europe-west1.gcp.commercetools.com', {
-        reqheaders: {
-          authorization: 'Bearer test-access-token',
-        },
-      })
-        .post('/test-project-key/customers', {
-          email: 'jimmy@gradientedge.com',
-          authenticationMode: 'ExternalAuth',
-        })
-        .reply(200, { customer: mockCustomer })
-      const commercetoolsAuth0 = new CommercetoolsAuth0(mockConfig)
-
-      const result = await commercetoolsAuth0.preRegistrationSync({
-        user: {
-          email: 'jimmy@gradientedge.com',
-        },
-      })
-
-      expect(result).toEqual(mockCustomer)
-    })
-
-    it('should throw an error if the customer already exists', async () => {
-      let error: any
-      nock('https://api.europe-west1.gcp.commercetools.com', {
-        reqheaders: {
-          authorization: 'Bearer test-access-token',
-        },
-      })
-        .post('/test-project-key/customers', {
-          email: 'jimmy@gradientedge.com',
-          authenticationMode: 'ExternalAuth',
-        })
-        .reply(400, {
-          statusCode: 400,
-          message: 'There is already an existing customer with the provided email.',
-          errors: [
-            {
-              code: 'DuplicateField',
-              message: 'There is already an existing customer with the provided email.',
-              duplicateValue: 'jimmy@gradientedge.com',
-              field: 'email',
-            },
-          ],
-        })
-      const commercetoolsAuth0 = new CommercetoolsAuth0(mockConfig)
-
-      try {
-        await commercetoolsAuth0.preRegistrationSync({
-          user: {
-            email: 'jimmy@gradientedge.com',
-          },
-        })
-      } catch (e) {
-        error = e
-      }
-
-      expect(error).toBeInstanceOf(CommercetoolsAuth0Error)
-      expect(error.message).toBe('Customer [jimmy@gradientedge.com] already exists in commercetools')
-      expect(error.code).toBe('CUSTOMER_EXISTS')
-    })
-
-    it('should throw an error if there was an unexpected error creating the customer', async () => {
-      let error: any
-      nock('https://api.europe-west1.gcp.commercetools.com', {
-        reqheaders: {
-          authorization: 'Bearer test-access-token',
-        },
-      })
-        .post('/test-project-key/customers', {
-          email: 'jimmy@gradientedge.com',
-          authenticationMode: 'ExternalAuth',
-        })
-        .reply(400)
-      const commercetoolsAuth0 = new CommercetoolsAuth0(mockConfig)
-
-      try {
-        await commercetoolsAuth0.preRegistrationSync({
-          user: {
-            email: 'jimmy@gradientedge.com',
-          },
-        })
-      } catch (e) {
-        error = e
-      }
-
-      expect(error).toBeInstanceOf(CommercetoolsAuth0Error)
-      expect(error.message).toBe('Error creating customer in commercetools: Request failed with status code 400')
-      expect(error.code).toBe('UNEXPECTED_ERROR')
     })
   })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,29 +46,6 @@ export interface PostLoginSyncParams {
   mergeCart: true | false | 'use_anonymous'
 }
 
-export interface PreRegistrationSyncParams {
-  /**
-   * Only defined if the customer has logged in in after having already
-   * added something to their cart as an anonymous customer
-   */
-  anonymousCustomerId?: string
-  /**
-   * The key of the commercetools store that this customer relates to
-   *
-   * Not required if customers are global.
-   */
-  storeKey?: string
-  /**
-   * User profile data as provided by Auth0
-   */
-  user: {
-    id?: string
-    email: string
-    firstName?: string
-    lastName?: string
-  }
-}
-
 export interface PostRegistrationSyncParams {
   /**
    * The customer id of the newly registered customer


### PR DESCRIPTION
The pre-registration action does not pass query string parameters and so provides no benefit over the post-login action for registering a customer