### PR TITLE
feat: add `timeoutMs` option to constructor

### DIFF
--- a/src/CommercetoolsAuth0.ts
+++ b/src/CommercetoolsAuth0.ts
@@ -10,7 +10,7 @@ import {
   GetCartParams,
   PostRegistrationSyncParams,
 } from './types'
-import { COMMERCETOOLS_REQUIRED_SCOPES } from './constants'
+import { COMMERCETOOLS_REQUIRED_SCOPES, DEFAULT_REQUEST_TIMEOUT_MS } from './constants'
 import { CommercetoolsAuth0ErrorCode } from './error/codes'
 
 export class CommercetoolsAuth0 {
@@ -20,6 +20,7 @@ export class CommercetoolsAuth0 {
   constructor(options: CommercetoolsAuth0Config) {
     this.config = options
     this.client = new CommercetoolsApi({
+      timeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
       ...options.commercetools,
       clientScopes: COMMERCETOOLS_REQUIRED_SCOPES,
     })

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,3 +5,8 @@ export const COMMERCETOOLS_REQUIRED_SCOPES = [
   'manage_customers', // For querying and creating customers
   'manage_orders', // For querying and updating carts
 ]
+
+/**
+ * The default milliseconds timeout value when making requests to commercetools
+ */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 5000

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface CommercetoolsAuth0Config {
     clientSecret: string
     region: Region
     projectKey: string
+    timeoutMs?: number
   }
 }
 


### PR DESCRIPTION
A default value of 5 seconds is defined in the constants file. The Auth0 timeout for an action is 10 seconds.