### PR TITLE
BREAKING CHANGE: Introduce customer details instead of commercetools customer object

### DIFF
--- a/src/CommercetoolsAuth0.ts
+++ b/src/CommercetoolsAuth0.ts
@@ -9,6 +9,7 @@ import {
   MergeAnonymousToAccountCartParams,
   MergeCartParams,
   GetCartParams,
+  CustomerDetails,
 } from './types'
 import { COMMERCETOOLS_REQUIRED_SCOPES, DEFAULT_REQUEST_TIMEOUT_MS } from './constants'
 import { CommercetoolsAuth0ErrorCode } from './error/codes'
@@ -53,12 +54,13 @@ export class CommercetoolsAuth0 {
    * Regardless of which of the above scenarios applies, we end up with the id of a
    * commercetools account customer. If we were
    */
-  public async postLoginSync(options: PostLoginSyncParams): Promise<Customer | null> {
-    let customer: Customer | null = null
+  public async postLoginSync(options: PostLoginSyncParams): Promise<CustomerDetails> {
     let accountCustomerId: string | undefined = options.accountCustomerId
+    let isNewCustomer = false
     if (!accountCustomerId) {
-      customer = await this.createCustomer(options)
+      const customer = await this.createCustomer(options)
       accountCustomerId = customer.id
+      isNewCustomer = true
     }
     if (options.mergeCart && options.anonymousCustomerId) {
       await this.mergeCart({
@@ -67,7 +69,11 @@ export class CommercetoolsAuth0 {
         accountCustomerId,
       })
     }
-    return customer
+    const customerDetails = await this.getCustomerDetails(accountCustomerId)
+    return {
+      ...customerDetails,
+      isNewCustomer,
+    }
   }
 
   /**
@@ -220,6 +226,38 @@ export class CommercetoolsAuth0 {
     }
 
     return null
+  }
+
+  /**
+   * Return the customer details from the Commercetools graphQl response
+   *
+   * @param id - Commercetools customer id
+   */
+  public async getCustomerDetails(customerId: string): Promise<Omit<CustomerDetails, 'isNewCustomer'>> {
+    let response
+    try {
+      response = await this.client.graphql({
+        data: {
+          query: `{
+            customer(id: "${customerId}") {
+              firstName
+              lastName
+              customerGroup {
+                key
+              }
+            }
+          }`,
+        },
+      })
+    } catch (error) {
+      console.log(`Error retrieving customer details for customer Id [${customerId}]`)
+    }
+    return {
+      id: customerId,
+      firstName: response?.data?.customer?.firstName || '',
+      lastName: response?.data?.customer?.lastName || '',
+      groupKey: response?.data?.customer?.customerGroup?.key || null,
+    }
   }
 
   /**

--- a/src/__tests__/mocks/customer.ts
+++ b/src/__tests__/mocks/customer.ts
@@ -1,4 +1,5 @@
 import { Customer } from '@gradientedge/commercetools-utils'
+import { CustomerDetails } from '../../types'
 
 export const mockCustomer: Customer = {
   id: '47d9dc26-03cf-40c7-90ab-fe531df37f29',
@@ -22,4 +23,22 @@ export const mockCustomer: Customer = {
   isEmailVerified: false,
   stores: [],
   authenticationMode: 'ExternalAuth',
+}
+
+export const mockGraphQlCustomer = {
+  customer: {
+    firstName: 'Jimmy',
+    lastName: 'Thomson',
+    customerGroup: {
+      key: 'gold',
+    },
+  },
+}
+
+export const mockCustomerDetails: CustomerDetails = {
+  id: 'account-customer-id-guid',
+  firstName: 'Jimmy',
+  lastName: 'Thomson',
+  groupKey: 'gold',
+  isNewCustomer: false,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,3 +99,11 @@ export interface MergeAnonymousToAccountCartParams {
   anonymousCustomerCart: Cart
   accountCustomerCart: Cart
 }
+
+export interface CustomerDetails {
+  id: string
+  firstName: string
+  lastName: string
+  groupKey: string | null
+  isNewCustomer: boolean
+}


### PR DESCRIPTION
Introduce `CustomerDetails` instead of Commercetools `Customer` object